### PR TITLE
fix(widgets): use `defer` when including the intervalwidget.js

### DIFF
--- a/src/django_interval/widgets.py
+++ b/src/django_interval/widgets.py
@@ -1,7 +1,16 @@
 from django.forms.widgets import Input
+from django.templatetags.static import static
+from django.utils.html import html_safe
+
+
+@html_safe
+class JSPath:
+    def __str__(self):
+        path = static("js/intervalwidget.js")
+        return '<script src="' + path + '" defer>'
 
 
 class IntervalWidget(Input):
     class Media:
-        js = ["js/intervalwidget.js",]
+        js = [JSPath()]
         css = {"all": ["css/intervalwidget.css"]}


### PR DESCRIPTION
Closes: #41
