### PR TITLE
feat(fields): set the auto_created attribute of the auto created fields

### DIFF
--- a/src/django_interval/fields.py
+++ b/src/django_interval/fields.py
@@ -21,7 +21,7 @@ class GenericDateIntervalField(CharField):
     """
 
     def add_generated_date_field(self, cls, name):
-        date_field = DateField(editable=False, blank=True, null=True)
+        date_field = DateField(editable=False, blank=True, null=True, auto_created=True)
         cls.add_to_class(name, date_field)
         setattr(self, f"_{name}", date_field)
 


### PR DESCRIPTION
auto_created is a "Boolean flag that indicates if the field was
automatically created ..." - so this seems to be appropriate.
This makes it easier to exclude the auto generated fields.
