### PR TITLE
fix(views): catch exception and pass error message on to template

### DIFF
--- a/src/django_interval/templates/django_interval/interval.html
+++ b/src/django_interval/templates/django_interval/interval.html
@@ -1,2 +1,6 @@
 {% load django_interval %}
-{% date_interval to_date from_date sort_date %}
+{% if error %}
+    {{ error }}
+{% else %}
+    {% date_interval to_date from_date sort_date %}
+{% endif %}

--- a/src/django_interval/views.py
+++ b/src/django_interval/views.py
@@ -14,12 +14,15 @@ class IntervalView(TemplateView):
         content_type = ContentType.objects.get_by_natural_key(app_label, model)
 
         if field := getattr(content_type.model_class(), kwargs.get("field"), None):
+            context = {}
             if datestring := self.request.GET.get("datestring"):
-                sort_date, from_date, to_date = field.calculate(datestring)
-                context = {
-                    "sort_date": sort_date,
-                    "from_date": from_date,
-                    "to_date": to_date,
-                }
+                context["original_string"] = datestring
+                try:
+                    sort_date, from_date, to_date = field.calculate(datestring)
+                    context["sort_date"] = sort_date
+                    context["from_date"] = from_date
+                    context["to_date"] = to_date
+                except Exception as e:
+                    context["error"] = str(e)
             return context
         raise Http404


### PR DESCRIPTION
If the parsing of the datestring fails we catch the exception instead of
showing a error trace to the user. We then write the exception message
in the context, this way we can show it to the user.
This also updates the template to include the error message if there is
one.

Closes: https://github.com/acdh-oeaw/django-interval/issues/53