### PR TITLE
fix(fields): explicitly populate generated fields during form save

### DIFF
--- a/src/django_interval/fields.py
+++ b/src/django_interval/fields.py
@@ -68,6 +68,10 @@ class GenericDateIntervalField(CharField):
         self._populate_fields(model_instance)
         return super().pre_save(model_instance, add)
 
+    def save_form_data(self, instance, data):
+        super().save_form_data(instance, data)
+        self._populate_fields(instance)
+
 
 class FuzzyDateParserField(GenericDateIntervalField):
     def __init__(


### PR DESCRIPTION
otherwise the `auto_created` fields are not being saved

Closes: #58
